### PR TITLE
H1 changes and added support for navigation in blog page

### DIFF
--- a/assets/styles/layouts/_Blog.scss
+++ b/assets/styles/layouts/_Blog.scss
@@ -52,6 +52,96 @@
 			z-index: 2;
 		}
 
+		&__navigation {
+			margin: 1.5em auto 0;
+
+			.nav {
+				display: inline-block;
+				font-weight: 600;
+			}
+
+			.menu-item-description {
+				display: none;
+			}
+
+			.menu-item {
+				display: inline-block;
+
+				+ li {
+					margin-left: 1em;
+				}
+			}
+
+			a {
+
+				@include color(color, font-color-dark);
+			}
+
+			@mixin highlight() {
+
+				@include color(color, primary-color);
+				position: relative;
+
+				&::after {
+					content: "";
+					position: absolute;
+					width: 100%;
+					border-bottom: 2px solid $dark-primary;
+					bottom: -0.5em;
+					left: 0;
+				}
+			}
+
+			.current-menu-item {
+
+				a {
+
+					@include highlight;
+
+					&::after {
+						display: none;
+					}
+				}
+			}
+
+			@media (min-width: $breakpoint-tablet) {
+				margin: 4.5em auto 7em;
+
+				.Blog__searchResults & {
+					margin: 4.5em auto 2em;
+				}
+
+				.current-menu-item {
+
+					a {
+
+						&::after {
+							display: block;
+						}
+					}
+				}
+			}
+
+			@media (min-width: $breakpoint-desktop) {
+				margin: 4.5em auto 4em;
+
+				.menu-item {
+
+					+ li {
+						margin-left: 3.25em;
+					}
+				}
+
+				a {
+
+					&:hover {
+
+						@include highlight;
+					}
+				}
+			}
+		}
+
 		&__search {
 			position: relative;
 			display: inline-block;
@@ -99,7 +189,7 @@
 			margin-top: 2.5em;
 
 			.wrapper {
-				padding-bottom: 17em;
+				padding-bottom: 5em;
 			}
 
 			&__title {

--- a/templates/content-archive-ms_academy.php
+++ b/templates/content-archive-ms_academy.php
@@ -5,7 +5,7 @@ set_source( 'academy', 'filter', 'js' );
 <div id="category" class="Category Academy">
 	<div class="Box Category__header Category__header--academy">
 		<div class="wrapper">
-			<h1 class="Category__header__title"><?php _e( 'Academy courses', 'Academy' ); ?></h1>
+			<h1 class="Category__header__title"><?php _e( 'Affiliate Marketing Academy', 'ms' ); ?></h1>
 			<p class="Category__header__subtitle"><?php _e( 'Become an affiliate marketing expert', 'ms' ); ?></p>
 			<div class="Category__header__search searchField">
 				<img class="searchField__icon" src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/icon-search_new_v2.svg" alt="<?php _e( 'Search', 'ms' ); ?>" />

--- a/templates/content-archive-ms_features.php
+++ b/templates/content-archive-ms_features.php
@@ -12,7 +12,7 @@ set_source( 'features', 'filter', 'js' );
 					<h1 class="Category__header__title"><?php single_cat_title(); ?></h1>
 					<div class="Category__header__subtitle"><p><?php the_archive_description(); ?></p></div>
 				<?php } else { ?>
-					<h1 class="Category__header__title"><?php _e( 'Features', 'ms' ); ?></h1>
+					<h1 class="Category__header__title"><?php _e( 'Post Affiliate Pro Features', 'ms' ); ?></h1>
 					<p class="Category__header__subtitle"><?php _e( 'Explore and get to know all features of Post Affiliate Pro. Find out out how our advanced affiliate software works, and how you can use each functionality to streamline your success.', 'ms' ); ?></p>
 				<?php } ?>
 

--- a/templates/content-archive.php
+++ b/templates/content-archive.php
@@ -10,6 +10,18 @@ set_custom_source( 'blogLazyLoad', 'js', array( 'app_js' ) );
 	<div class="Blog__header Block--lines--header">
 		<div class="wrapper wrapper__extended">
 			<h1 class="Blog__header__title"><?php single_cat_title(); ?></h1>
+			<div class="Blog__header__navigation">
+				<?php
+				if ( has_nav_menu( 'blog_filter_navigation' ) ) :
+					wp_nav_menu(
+						array(
+							'theme_location' => 'blog_filter_navigation',
+							'menu_class'     => 'nav',
+						)
+					);
+				endif;
+				?>
+			</div>
 		</div>
 	</div>
 
@@ -84,7 +96,7 @@ set_custom_source( 'blogLazyLoad', 'js', array( 'app_js' ) );
 								</div>
 							</div>
 							<svg width="100%" height="100%" preserveAspectRatio="xMidYMax meet" class="SliderCutted__inn--mask" viewBox="0 0 1120 336"
-									 xmlns="http://www.w3.org/2000/svg" xml:space="preserve">
+									xmlns="http://www.w3.org/2000/svg" xml:space="preserve">
 							<path
 									d="M64 76.998c0-8.836 7.163-16 16-16h1088c8.84 0 16 7.17 16 16.006v104.994c0 8.837-7.63 15.744-15.23 20.26-9.38 5.58-15.77 15.932-15.77 26.74 0 10.808 6.39 21.16 15.77 26.74 7.6 4.516 15.23 11.423 15.23 20.26v104.994c0 8.836-7.16 16.006-16 16.006H80c-8.837 0-16-7.163-16-16v-105c0-8.837 7.629-15.744 15.225-20.26C88.611 250.158 95 239.806 95 228.998c0-10.808-6.389-21.16-15.775-26.74C71.629 197.742 64 190.835 64 181.998v-105Z"
 									style="fill:#fff" transform="translate(-64 -60.998)" />


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed h1 titles and added support for navigation in Blog page

**Testing instructions**
to see nav in blog page properly, we need to add it in WP -> appearance -> menus -> Blog Filter Navigation

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] My commits follow the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#460
