### PR TITLE
[615] Item title size in How-to widget

### DIFF
--- a/lib/widgets/qu-howtos/layouts/howto-item.php
+++ b/lib/widgets/qu-howtos/layouts/howto-item.php
@@ -41,9 +41,9 @@ function howto_item( $attr ) {
 		<div class="qu-HowToItem" data-howtoitem="' . $attr['howtoItemId'] . '" 
 			itemprop="step" itemscope itemtype="https://schema.org/HowToSection">
 			<div class="qu-HowToItem__header">
-				<h2 class="qu-HowToItem__header--text" itemprop="name">' . 
+				<h3 class="qu-HowToItem__header--text" itemprop="name">' .
 					$attr['header'] 
-		. ' </h2>
+		. ' </h3>
 			</div>
 			<div class="qu-HowToItem__content" itemprop="itemListElement" itemscope itemtype="https://schema.org/HowToStep">
 				<div class="qu-HowToItem__content--inn" itemprop="text" >


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Title of item changed from h2 to h3

**Testing instructions**
Check How-to widget titles

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#615
