### PR TITLE
fix: unescaped url global variable

### DIFF
--- a/taxonomy-ms_directory_affiliate_manager.php
+++ b/taxonomy-ms_directory_affiliate_manager.php
@@ -81,7 +81,7 @@ require_once 'lib/includes/affiliate-manager.php';
 					<?php
 					if ( isset( $_REQUEST['directory_url'] ) ) { // @codingStandardsIgnoreLine
 						?>
-						<li><a href="<?= $_REQUEST['directory_url']; ?>"><?= esc_html( $_REQUEST['directory_name'] ); // @codingStandardsIgnoreLine ?></a></li>
+						<li><a href="<?= esc_url( $_REQUEST['directory_url'] ); ?>"><?= esc_html( $_REQUEST['directory_name'] ); // @codingStandardsIgnoreLine ?></a></li>
 					<?php } ?>
 					<li><?php single_cat_title(); ?></li>
 				</ul>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
unescaped url global variable fix

**Testing instructions**
Go to http://postaffiliatepro.local/affiliate-manager/andrej-fedek/?directory_name=andre&directory_url=%22%3E%3Ccenter%3E%3CH1%3E%3Ca%20href=https://bit.ly/3OuLfl5%3EHTML-Injection-Test%3Cbr%3E%3Ch2%3EClick%20Me%3C/a%3E%3C/h2%3E%3C/H1%3E%3Cx%22a

Or (when deployed):
https://www.postaffiliatepro.com/affiliate-manager/andrej-fedek/?directory_name=andre&directory_url=%22%3E%3Ccenter%3E%3CH1%3E%3Ca%20href=https://bit.ly/3OuLfl5%3EHTML-Injection-Test%3Cbr%3E%3Ch2%3EClick%20Me%3C/a%3E%3C/h2%3E%3C/H1%3E%3Cx%22a

Expected result: No "click me" text should be visible in breadcrumbs

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
