### PR TITLE
fix: disable force moving js to footer

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -15,7 +15,6 @@ add_action(
 			array(
 				'clean-up',
 				'disable-trackbacks',
-				'js-to-footer',
 				'nice-search',
 			)
 		);


### PR DESCRIPTION
**Changes proposed in this Pull Request**
disable force moving of js to footer due to many errors

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
