### PR TITLE
[734] fix: remove schema.org fix

### DIFF
--- a/functions/content-filters.php
+++ b/functions/content-filters.php
@@ -414,26 +414,3 @@ add_filter(
 		return ' &hellip; <a href="' . get_permalink() . '">' . __( 'Read More', 'ms' ) . '</a>';
 	}
 );
-
-// Fixes schema url hostname back to .com domain
-function change_schema_hostname( $data ) {
-	$protocol = 'http:\/\/';
-	$hostname = 'www.postaffiliatepro.com';
-	
-	if ( isset( $_SERVER['HTTPS'] ) &&
-			( $_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1 ) || //@codingStandardsIgnoreLine
-			isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) &&
-			$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) { //@codingStandardsIgnoreLine
-		$protocol = 'https:\/\/';
-	}
-
-	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-		$hostname = $_SERVER['SERVER_NAME']; //@codingStandardsIgnoreLine
-	}
-
-	$json   = wp_json_encode( $data );
-	$output = preg_replace( '/http(s?):\\\\\/\\\\\/(www\.)?postaffiliatepro\.(.+?)\//', $protocol . $hostname . '\/', $json );
-	return $output;
-}
-
-add_filter( 'wpseo_schema_graph', 'change_schema_hostname', 10, 2 );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
- remove schema.org fix

_Note: The function is generating tons of PHP Warning with newest Yoast SEO_ `PHP Warning: Invalid argument supplied for foreach() in /var/www/html/web/app/plugins/wordpress-seo/src/generators/schema-generator.php on line 231`

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#734
