### PR TITLE
[2965] Integrations are missing in mobile menu

### DIFF
--- a/assets/styles/layouts/Header.scss
+++ b/assets/styles/layouts/Header.scss
@@ -202,6 +202,41 @@ body {
 								> li {
 									padding: 0;
 
+									&.show-only-mobile {
+										display: flex;
+										position: relative;
+										background-color: $bg-color;
+
+										&.current-menu-item {
+											background-color: $label-use-for-bg;
+										}
+
+										.icon {
+
+											@include square(1.25rem);
+											display: block;
+											position: absolute;
+											top: 0.25em;
+											left: 1em;
+											margin-top: 0.9em;
+											color: $saturated-blue !important;
+											z-index: 1;
+											pointer-events: none;
+										}
+
+										a {
+											display: flex;
+											width: 100%;
+											flex-direction: column;
+											padding: 14px 3.125em;
+											align-items: flex-start;
+
+											&::after {
+												content: unset;
+											}
+										}
+									}
+
 									&.label-product {
 
 										li.current-menu-item {
@@ -863,6 +898,10 @@ body {
 		}
 	}
 
+
+	.show-only-mobile {
+		display: none;
+	}
 
 	@media (min-width: $breakpoint-tablet-landscape) {
 		display: flex;

--- a/composer.lock
+++ b/composer.lock
@@ -349,7 +349,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/QualityUnit/wordpress-icons.git",
-                "reference": "c3d4c3a7c1d32191b5dd3a27b9486949874caf80"
+                "reference": "8ac4f5135ed18586a9f6b2d19238af575f4f4100"
             },
             "default-branch": true,
             "type": "wordpress-icons",
@@ -357,7 +357,7 @@
                 "GPL-2.0-only"
             ],
             "description": "QU WordPress Themes icons",
-            "time": "2024-03-15T12:56:36+00:00"
+            "time": "2024-04-05T12:33:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1939,5 +1939,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added styles for the integrations link to mobile menu

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2965
