### PR TITLE
[2982] Not valid Schema.org in breadcrumbs

### DIFF
--- a/functions/import-functions.php
+++ b/functions/import-functions.php
@@ -124,7 +124,7 @@ function site_breadcrumb( $breadcrumb = array() ) {
 
 			if ( is_tax( 'ms_directory_affiliate_manager' ) ) {
 				$translated_text = __( 'Affiliate manager directory', 'ms' );
-				$translated_url = apply_filters( 'wpml_permalink', '/affiliate-program-directory/', ICL_LANGUAGE_CODE );
+				$translated_url = __( '/affiliate-program-directory/', 'ms' );
 				array_splice( $breadcrumb, 1, 0, array( array( $translated_text, $translated_url ) ) );
 			}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I rewrote breadcrumb function for taxonomy affiliate manager. I replaced the wpml function that created the link with a relative path

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2982