### PR TITLE
[3020] PAP alternatives issue

### DIFF
--- a/functions/import-functions.php
+++ b/functions/import-functions.php
@@ -93,11 +93,15 @@ function site_breadcrumb( $breadcrumb = array() ) {
 			$post_type = get_post_type_object( get_post_type() );
 			if ( $post_type ) {
 				$post_type_name = $post_type->labels->name;
+				$alternatives_name = __( 'Alternatives', 'ms' );
 				if ( 'Posts' == $post_type_name ) {
 					$categories = get_the_category();
 					if ( isset( $categories[0] ) ) {
 						$breadcrumb[] = array( $categories[0]->name, get_category_link( $categories[0]->term_id ) );
 					}
+				} elseif ( $alternatives_name == $post_type_name ) {
+					$post_type_url = __( '/alternatives/', 'ms' );
+					$breadcrumb[]  = array( $post_type_name, $post_type_url );
 				} else {
 					$post_type_url = get_post_type_archive_link( $post_type->name );
 					$breadcrumb[]  = array( $post_type_name, $post_type_url );
@@ -182,6 +186,7 @@ function site_breadcrumb( $breadcrumb = array() ) {
 	$output      .= '<div class="breadcrumbs">';
 	$output      .= '<div class="breadcrumbs-inner">';
 	$output      .= '<ol itemscope itemtype="https://schema.org/BreadcrumbList">';
+
 	foreach ( $breadcrumb as $item ) {
 		$item_name = str_replace( '^', '', $item[0] );
 		$output   .= '<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">';

--- a/lib/post-types/alternatives.php
+++ b/lib/post-types/alternatives.php
@@ -10,7 +10,7 @@ add_action(
 			'name_admin_bar' => __( 'Alternative', 'ms' ),
 		);
 		$rewrite = array(
-			'slug'       => 'alternatives',
+			'slug'       => 'alternatives-posts',
 			'with_front' => true,
 			'pages'      => true,
 			'feeds'      => false,
@@ -28,7 +28,7 @@ add_action(
 			'show_in_admin_bar'   => true,
 			'show_in_nav_menus'   => true,
 			'can_export'          => true,
-			'has_archive'         => true,
+			'has_archive'         => false,
 			'exclude_from_search' => false,
 			'publicly_queryable'  => true,
 			'rewrite'             => $rewrite,


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I had to change the slug on PT alternatives because the Alternatives page had the same slug as the alternatives post type slug and then it doesn't work. I disabled the archive page for this post type and had to redirect the breadcrumb link

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3020
