### PR TITLE
 [3135] Hide title "Related articles" if empty from urslslab shortcode

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -3,7 +3,6 @@
  * Template Name: Elementor
  */
 ?>
-
 <?php
 while ( have_posts() ) :
 	the_post();
@@ -11,13 +10,19 @@ while ( have_posts() ) :
 	<?php the_content(); ?>
 
 	<?php
-	if ( ! is_page( array( 'sitemap' ) ) ) {
-		?>
-		<div class="SimilarSources flowhunt-skip">
-			<div class="wrapper">
-				<div class="SimilarSources__title h3"><?php _e( 'Related Articles to ', 'ms' ); ?><?php the_title(); ?></div>
-				<?php echo do_shortcode( '[urlslab-related-resources related-count="6" show-image="true" show-summary="true"]' ); ?>
+	if ( ! is_page( array( 'sitemap' ) ) && ! is_front_page() ) {
+
+		$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+		if ( ! empty( $related_resources ) ) {
+			?>
+			<div class="SimilarSources">
+				<div class="wrapper">
+					<div class="SimilarSources__title h3"><?php _e( 'Related Articles to ', 'ms' ); ?><?php the_title(); ?></div>
+					<?= wp_kses_post( $related_resources ); ?>
+				</div>
 			</div>
-		</div>
 		<?php } ?>
+	<?php } ?>
+
 <?php endwhile; ?>

--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,7 @@ define( 'THEME_VERSION', '1.15.22' );
 		'functions/header-banners.php', // Import ShortCodes
 		'functions/create-language-menu.php', // Function for generate languages
 		'functions/dynamic-award-badges.php', // Function to place award badges dynamically
-		'functions/dynamic-award-badges.php', // Function to place award badges dynamically
+		'functions/urlslab-related-posts', // Function to place award badges dynamically
 	);
 
 	foreach ( $theme_includes as $file ) {

--- a/functions/urlslab-related-posts.php
+++ b/functions/urlslab-related-posts.php
@@ -1,0 +1,17 @@
+<?php
+
+function urlslab_display_related_resources() {
+	// do_shortcode for related resources
+	$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+	if ( ! empty( $related_resources ) ) :
+		?>
+		<div class="Post__content__resources">
+			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
+			<div class="SimilarSources">
+				<?= wp_kses_post( $related_resources ); ?>
+			</div>
+		</div>
+		<?php
+	endif;
+}

--- a/template-academy.php
+++ b/template-academy.php
@@ -66,13 +66,7 @@ set_custom_source( 'custom_lightbox', 'js' );
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -37,12 +37,7 @@
 			<div class="Content">
 				<?php the_content(); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/template-blog.php
+++ b/template-blog.php
@@ -84,12 +84,6 @@ set_custom_source( 'custom_lightbox', 'js' );
 	<div class="BlogPost__content Content" itemprop="articleBody">
 		<?php the_content(); ?>
 
-		<div class="Post__content__resources">
-			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-			<div class="SimilarSources flowhunt-skip">
-				<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-			</div>
-		</div>
+		<?php urlslab_display_related_resources(); ?>
 	</div>
 </div>

--- a/templates/content-page.php
+++ b/templates/content-page.php
@@ -12,14 +12,18 @@
 
 				<?php
 				if ( ! is_page( array( 'sitemap' ) ) ) {
-					?>
-					<div class="SimilarSources SimilarSources--blog flowhunt-skip">
-						<div class="wrapper">
-							<div class="SimilarSources__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
 
-							<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
+					$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+					if ( ! empty( $related_resources ) ) {
+						?>
+						<div class="SimilarSources SimilarSources--blog">
+							<div class="wrapper">
+								<div class="SimilarSources__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
+								<?= wp_kses_post( $related_resources ); ?>
+							</div>
 						</div>
-					</div>
+					<?php } ?>
 				<?php } ?>
 			</div>
 

--- a/templates/content-single-ms_academy.php
+++ b/templates/content-single-ms_academy.php
@@ -70,13 +70,7 @@ if ( $categories && $categories_url ) {
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_directory.php
+++ b/templates/content-single-ms_directory.php
@@ -836,13 +836,7 @@ function manager_industry( $manager_industry ) {
 						<img class="CTA__image" src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/cta_img_new.png" alt="<?php _e( 'Build your own affiliate program', 'ms' ); ?>" />
 					</div>
 
-					<div class="Post__content__resources">
-						<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-						<div class="SimilarSources flowhunt-skip">
-							<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-						</div>
-					</div>
+					<?php urlslab_display_related_resources(); ?>
 				</div>
 			</div>
 		</div>

--- a/templates/content-single-ms_features.php
+++ b/templates/content-single-ms_features.php
@@ -130,13 +130,7 @@ function get_tags_from_features( $features, $url, $versions ) {
 
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_glossary.php
+++ b/templates/content-single-ms_glossary.php
@@ -47,13 +47,7 @@ $page_header_args = array(
 
 				<?= do_shortcode( '[expert-note]' ); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_integrations.php
+++ b/templates/content-single-ms_integrations.php
@@ -137,13 +137,7 @@ foreach ( $integrations_config as $config ) {
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 
 		</div>

--- a/templates/content-single-ms_research.php
+++ b/templates/content-single-ms_research.php
@@ -80,13 +80,7 @@ do_action( 'wpml_switch_language', $current_lang );
 				<?php the_content(); ?>
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_templates.php
+++ b/templates/content-single-ms_templates.php
@@ -65,13 +65,7 @@ if ( $categories && $categories_url ) {
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_videos.php
+++ b/templates/content-single-ms_videos.php
@@ -79,13 +79,7 @@ if ( $categories && $categories_url ) {
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 		<div class="Post__sidebar flowhunt-skip">

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -126,12 +126,7 @@ if ( isset( $categories ) ) {
 				</div>
 
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources flowhunt-skip">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changes proposed in this Pull Request
I created a function to display related articles via a shortcode from urlslab and added a condition to display the title only if the urlslab shortcode displays something and also added a url parameter to the shortcode. And i replaced old code in the all templates

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3135
