### PR TITLE
[3162] Blacklist some parameters which are not forwarded to other links

### DIFF
--- a/assets/scripts/app/queryParamsToUrls.js
+++ b/assets/scripts/app/queryParamsToUrls.js
@@ -1,15 +1,35 @@
 // adds all query params from incoming URL to urls on page
-( () => {
-	const queryParams = new URL( window.location ).searchParams;
 
+( () => {
+	const currentHostname = window.location.hostname;
+
+	// If the hostname contains 'admin', exit the script
+	if ( currentHostname.includes( 'admin' ) ) {
+		return;
+	}
+
+	const queryParams = new URL( window.location ).searchParams;
+	const blacklist = [ 'p' ];
 	const allUrls = document.querySelectorAll( 'a[href]' );
 
 	allUrls.forEach( ( url ) => {
+		const currentHref = url.getAttribute( 'href' );
+
+		// Skip links that are empty or placeholders
+		if ( currentHref === '#' || currentHref === '#0' || currentHref === '' ) {
+			return;
+		}
+
 		const currentUrl = new URL( url.href );
 
+		// Add query parameters to the URL if not blacklisted
 		queryParams.forEach( ( value, key ) => {
-			currentUrl.searchParams.set( key, value );
+			if ( ! blacklist.includes( key ) ) {
+				currentUrl.searchParams.set( key, value );
+			}
 		} );
+
+		// Update the URL if the hostname contains 'liveagent' or 'live-agent'
 		if ( currentUrl.hostname.includes( 'postaffiliate' ) ) {
 			url.href = currentUrl.toString();
 		}

--- a/assets/scripts/app/queryParamsToUrls.js
+++ b/assets/scripts/app/queryParamsToUrls.js
@@ -29,7 +29,7 @@
 			}
 		} );
 
-		// Update the URL if the hostname contains 'liveagent' or 'live-agent'
+		// Update the URL if the hostname contains 'postaffiliate'
 		if ( currentUrl.hostname.includes( 'postaffiliate' ) ) {
 			url.href = currentUrl.toString();
 		}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I'm adding a blacklist to exclude some parameters from the JS function for adding parameters to URLs.
and added a condition to check if I'm on the admin.postaffiliate.com domain because we don't need to add parameters to the developer website

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3162
