### PR TITLE
[3386] - language field hidden demo form

### DIFF
--- a/assets/styles/layouts/tests/RequestDemo.scss
+++ b/assets/styles/layouts/tests/RequestDemo.scss
@@ -71,11 +71,7 @@ body {
 
 	iframe {
 		width: 100% !important;
-
-		@media (min-width: $breakpoint-tablet) {
-			min-height: 670px;
-			max-height: 670px;
-		}
+		height: auto;
 	}
 
 	.elementor-section .elementor-container {

--- a/assets/styles/layouts/tests/RequestDemo.scss
+++ b/assets/styles/layouts/tests/RequestDemo.scss
@@ -73,13 +73,8 @@ body {
 		width: 100% !important;
 
 		@media (min-width: $breakpoint-tablet) {
-			min-height: 637px;
-			max-height: 637px;
-		}
-
-		@media (min-width: $breakpoint-desktop) {
-			min-height: 579px;
-			max-height: 579px;
+			min-height: 670px;
+			max-height: 670px;
 		}
 	}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed styles for visible language field on form of demo page

**Testing instructions**
- Go to /demo/ page and check field "Consulatation call language",
should be visible

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3386