### PR TITLE
[3587] - fix: update trial-related text in trial widget

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -73,7 +73,7 @@ add_action(
 				'name'          => __( 'Footer Column #1', 'ms' ),
 				'id'            => 'footer_column_1',
 				'before_widget' => '<div class="%1$s %2$s">',
-				'after_widget'  => '<div class="Footer__top__cta"><a href="' . __( '/trial/' ) . '" class="Button Button--outline"><span>' . __( 'Start free trial' ) . '</span></a><a href="' . __( '/demo/' ) . '" class="Button Button--full"><span>' . __( 'Consult an Expert' ) . '</span></a></div></div>',
+				'after_widget'  => '<div class="Footer__top__cta"><a href="' . __( '/trial/' ) . '" class="Button Button--outline"><span>' . __( 'Start a free trial' ) . '</span></a><a href="' . __( '/demo/' ) . '" class="Button Button--full"><span>' . __( 'Consult an Expert' ) . '</span></a></div></div>',
 				'before_title'  => '<div class="Footer__top__column__title Footer__top__column__title--image h5"><img src="' . get_template_directory_uri() . '/assets/images/pap-logo.svg" alt="' . get_bloginfo( 'name' ) . '">',
 				'after_title'   => '</div>',
 			)

--- a/lib/shortcodes/signup-form-network.php
+++ b/lib/shortcodes/signup-form-network.php
@@ -10,10 +10,10 @@ function ms_signup_network_form( $atts ) {
 
 	$atts = shortcode_atts(
 		array(
-			'title'    => __( 'Start Free Trial', 'ms' ),
-			'label1'   => __( '30 days free trial', 'ms' ),
+			'title'    => __( 'Start a Free Trial', 'ms' ),
+			'label1'   => __( '30-day free trial', 'ms' ),
 			'tooltip1' => __( 'Free trial for 30 days with a company email', 'ms' ),
-			'label2'   => __( 'No Credit Card required', 'ms' ),
+			'label2'   => __( 'No credit card required', 'ms' ),
 			'button'   => __( 'Create account for FREE', 'ms' ),
 		),
 		$atts,

--- a/lib/shortcodes/signup-form-trial.php
+++ b/lib/shortcodes/signup-form-trial.php
@@ -14,9 +14,9 @@ function ms_signup_form_trial() {
 	<style type="text/css">
 		.Signup__form input{width:100%}.Signup__form__item{position: relative}.Signup__form__icon{fill: #bec2c9;position: absolute;z-index: 3;top: 50%;-webkit-transform: translateY(-50%);-ms-transform: translateY(-50%);transform: translateY(-50%);left: 1.3125em;width: 1.375em;}
 	</style>
-	
+
 	<div class="Signup__form">
-		<h3 class="Signup__form__title"><?php _e( 'Start Free Trial', 'ms' ); ?></h3>
+		<h3 class="Signup__form__title"><?php _e( 'Start a Free Trial', 'ms' ); ?></h3>
 
 		<form data-form-type="signup-trial-form" data-id="signup" data-plan-type="Trial" data-free-form>
 			<input data-id="grecaptcha" name="grecaptcha" type="hidden" value="" autocomplete="off">

--- a/lib/shortcodes/signup-form.php
+++ b/lib/shortcodes/signup-form.php
@@ -10,10 +10,10 @@ function ms_signup_form( $atts ) {
 
 	$atts = shortcode_atts(
 		array(
-			'title'    => __( 'Start Free Trial', 'ms' ),
-			'label1'   => __( '30 days free trial', 'ms' ),
+			'title'    => __( 'Start a Free Trial', 'ms' ),
+			'label1'   => __( '30-day free trial', 'ms' ),
 			'tooltip1' => __( 'Free trial for 30 days with a company email', 'ms' ),
-			'label2'   => __( 'No Credit Card required', 'ms' ),
+			'label2'   => __( 'No credit card required', 'ms' ),
 			'button'   => __( 'Create account for FREE', 'ms' ),
 		),
 		$atts,

--- a/template-trial-network.php
+++ b/template-trial-network.php
@@ -43,7 +43,7 @@
 					</a>
 				</div>
 				<h1 class="Trial__main__title"><?php _e( 'Try Our 1-Month <span class="highlight-background">Free Trial</span>', 'ms' ); ?></h1>
-				<p class="Trial__main__text"><?php _e( 'Experience working with PostAffiliatePro for free with our 30 days free trial. Enjoy testing every feature needed for your business starting today.', 'ms' ); ?></p>
+				<p class="Trial__main__text"><?php _e( 'Experience working with PostAffiliatePro for free with our 30-day free trial. Enjoy testing every feature needed for your business starting today.', 'ms' ); ?></p>
 
 				<?= do_shortcode( '[signupform-network]' ); ?>
 			</div>

--- a/template-trial.php
+++ b/template-trial.php
@@ -45,7 +45,7 @@
 					</a>
 				</div>
 				<h1 class="Trial__main__title"><?php _e( 'Try Our 1-Month <span class="highlight-background">Free Trial</span>', 'ms' ); ?></h1>
-				<p class="Trial__main__text"><?php _e( 'Experience working with PostAffiliatePro for free with our 30 days free trial. Enjoy testing every feature needed for your business starting today.', 'ms' ); ?></p>
+				<p class="Trial__main__text"><?php _e( 'Experience working with PostAffiliatePro for free with our 30-day free trial. Enjoy testing every feature needed for your business starting today.', 'ms' ); ?></p>
 
 				<?= do_shortcode( '[signupform]' ); ?>
 			</div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -370,6 +370,6 @@ if ( show_demo_bar() !== false ) {
 <?php } ?>
 
 <div class="trial__sticky__button">
-	<a href="<?= esc_url( '/trial/' ); ?>"><?= esc_html( 'Start Free Trial', 'ms' ); ?></a>
+	<a href="<?= esc_url( '/trial/' ); ?>"><?= esc_html( 'Start a Free Trial', 'ms' ); ?></a>
 	<span class="trial__sticky__button--close"><svg class="icon-close"><use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#close' ); ?>"></use></svg></span>
 </div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed grammatical errors in the "Start free trial" widget

**Testing instructions**
- Go to trial page or e.g. /affiliate-tracking-software/and check texts and button
- Should be "Experience working with PostAffiliatePro for free with our 30-day free trial.", "Start a free trial", "No credit card required" and button "30-day free trial"

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3587
